### PR TITLE
GetRecordingsList: fix variable names

### DIFF
--- a/src/VNSIData.cpp
+++ b/src/VNSIData.cpp
@@ -926,9 +926,9 @@ PVR_ERROR cVNSIData::GetRecordingsList(ADDON_HANDLE handle)
         tag.iChannelUid = uuid;
       uint8_t type = vresp->extract_U8();
       if (type == 1)
-	tag.iChannelUid = PVR_RECORDING_CHANNEL_TYPE_TV;
+	tag.channelType = PVR_RECORDING_CHANNEL_TYPE_RADIO;
       else if (type == 2)
-	tag.iChannelUid = PVR_RECORDING_CHANNEL_TYPE_RADIO;
+	tag.channelType = PVR_RECORDING_CHANNEL_TYPE_TV;
       else
 	tag.channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
     }


### PR DESCRIPTION
cVNSIData::GetRecordingsList(): fix variable name and use type definitions of vnsiserver.

Eliminates/reduces the 
```WARNING: CPVRRecording::CPVRRecording - unable to determine channel type. Defaulting to TV.```
log messages and moves radio recordings from TV to RADIO section.
