### PR TITLE
client: delete cVNSI{Demux,Recording} on open error

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -717,7 +717,13 @@ bool OpenLiveStream(const PVR_CHANNEL &channel)
   {
     VNSIDemuxer = new cVNSIDemux;
     IsRealtime = true;
-    return VNSIDemuxer->OpenChannel(channel);
+    if (!VNSIDemuxer->OpenChannel(channel)) {
+      delete VNSIDemuxer;
+      VNSIDemuxer = nullptr;
+      return false;
+    }
+
+    return true;
   }
   catch (std::exception e)
   {
@@ -876,7 +882,14 @@ bool OpenRecordedStream(const PVR_RECORDING &recording)
   VNSIRecording = new cVNSIRecording;
   try
   {
-    return VNSIRecording->OpenRecording(recording);
+    if (!VNSIRecording->OpenRecording(recording)) {
+      VNSIRecording->Close();
+      delete VNSIRecording;
+      VNSIRecording = nullptr;
+      return false;
+    }
+
+    return true;
   }
   catch (std::exception e)
   {


### PR DESCRIPTION
Fixes various accesses to uninitialized variables, because those
functions leave a defunct and uninitialized object behind.  For
example:

```
 Thread 21 VideoPlayer:
 Conditional jump or move depends on uninitialised value(s)
    at 0x172696B: CVideoPlayer::UpdatePlayState(double) (VideoPlayer.cpp:4714)
    by 0x1717153: CVideoPlayer::Prepare() (VideoPlayer.cpp:1373)
    by 0x171723D: CVideoPlayer::Process() (VideoPlayer.cpp:1382)
    by 0x19E44B8: CThread::Action() (Thread.cpp:211)
    by 0x19E4167: CThread::staticThread(void*) (Thread.cpp:127)
    by 0x56AC5A9: start_thread (pthread_create.c:463)
    by 0xE2E9CBE: clone (clone.S:95)
  Uninitialised value was created by a heap allocation
    at 0x54991FF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x307051B3: OpenLiveStream (in /usr/local/stow/kodi-x11/lib/kodi/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.so.3.5.3)
    by 0x1D6ED20: PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(KodiToAddonFuncTable_PVR const*)#1}::operator()(KodiToAddonFuncTable_PVR const*) const (PVRClient.cpp:1276)
    by 0x1D78396: std::_Function_handler<PVR_ERROR (KodiToAddonFuncTable_PVR const*), PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(KodiToAddonFuncTable_PVR const*)#1}>::_M_invoke(std::_Any_data const&, KodiToAddonFuncTable_PVR const*&&) (std_function.h:302)
    by 0x1D81620: std::function<PVR_ERROR (KodiToAddonFuncTable_PVR const*)>::operator()(KodiToAddonFuncTable_PVR const*) const (std_function.h:706)
    by 0x1D6EABD: PVR::CPVRClient::DoAddonCall(char const*, std::function<PVR_ERROR (KodiToAddonFuncTable_PVR const*)>, bool, bool) const (PVRClient.cpp:1245)
    by 0x1D6EE32: PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&) (PVRClient.cpp:1278)
    by 0x2034FFC: PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(std::shared_ptr<PVR::CPVRClient> const&)#1}::operator()(std::shared_ptr<PVR::CPVRClient> const&) const (PVRClients.cpp:562)
    by 0x203ACD9: std::_Function_handler<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&), PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(std::shared_ptr<PVR::CPVRClient> const&)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<PVR::CPVRClient> const&) (std_function.h:302)
    by 0x2044814: std::function<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&)>::operator()(std::shared_ptr<PVR::CPVRClient> const&) const (std_function.h:706)
    by 0x203803C: PVR::CPVRClients::ForCreatedClient(char const*, int, std::function<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&)>) const (PVRClients.cpp:1142)
    by 0x2035061: PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&) (PVRClients.cpp:562)
```

Or this one:

```
 Thread 31 PVRGUIInfo:
 Conditional jump or move depends on uninitialised value(s)
    at 0x205609D: PVR::CPVRGUIInfo::UpdatePlayingTag() (PVRGUIInfo.cpp:1773)
    by 0x204CC3F: PVR::CPVRGUIInfo::Process() (PVRGUIInfo.cpp:188)
    by 0x19E44B8: CThread::Action() (Thread.cpp:211)
    by 0x19E4167: CThread::staticThread(void*) (Thread.cpp:127)
    by 0x56AC5A9: start_thread (pthread_create.c:463)
    by 0xE2E9CBE: clone (clone.S:95)
  Uninitialised value was created by a heap allocation
    at 0x54991FF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x307051B3: OpenLiveStream (in /usr/local/stow/kodi-x11/lib/kodi/addons/pvr.vdr.vnsi/pvr.vdr.vnsi.so.3.5.3)
    by 0x1D6ED20: PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(KodiToAddonFuncTable_PVR const*)#1}::operator()(KodiToAddonFuncTable_PVR const*) const (PVRClient.cpp:1276)
    by 0x1D78396: std::_Function_handler<PVR_ERROR (KodiToAddonFuncTable_PVR const*), PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(KodiToAddonFuncTable_PVR const*)#1}>::_M_invoke(std::_Any_data const&, KodiToAddonFuncTable_PVR const*&&) (std_function.h:302)
    by 0x1D81620: std::function<PVR_ERROR (KodiToAddonFuncTable_PVR const*)>::operator()(KodiToAddonFuncTable_PVR const*) const (std_function.h:706)
    by 0x1D6EABD: PVR::CPVRClient::DoAddonCall(char const*, std::function<PVR_ERROR (KodiToAddonFuncTable_PVR const*)>, bool, bool) const (PVRClient.cpp:1245)
    by 0x1D6EE32: PVR::CPVRClient::OpenLiveStream(std::shared_ptr<PVR::CPVRChannel> const&) (PVRClient.cpp:1278)
    by 0x2034FFC: PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(std::shared_ptr<PVR::CPVRClient> const&)#1}::operator()(std::shared_ptr<PVR::CPVRClient> const&) const (PVRClients.cpp:562)
    by 0x203ACD9: std::_Function_handler<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&), PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&)::{lambda(std::shared_ptr<PVR::CPVRClient> const&)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<PVR::CPVRClient> const&) (std_function.h:302)
    by 0x2044814: std::function<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&)>::operator()(std::shared_ptr<PVR::CPVRClient> const&) const (std_function.h:706)
    by 0x203803C: PVR::CPVRClients::ForCreatedClient(char const*, int, std::function<PVR_ERROR (std::shared_ptr<PVR::CPVRClient> const&)>) const (PVRClients.cpp:1142)
    by 0x2035061: PVR::CPVRClients::OpenStream(std::shared_ptr<PVR::CPVRChannel> const&) (PVRClients.cpp:562)

```